### PR TITLE
adjusted code for solaris compliance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: WeibullR
-Version: 1.0.5
-Date: 2018-4-11
+Version: 1.0.6
+Date: 2018-4-13
 Title: Weibull Analysis for Reliability Engineering
 Authors@R: c(person("David", "Silkworth", email = "djsilk@openreliability.org", role = "aut"), person("Jurgen", "Symynck", role = "aut"), person("Jacob", "Ormerod", email = "jake@openreliability.org", role = "cre"), person("OpenReliability.org", role = "cph"))
 Description: Life data analysis in the graphical tradition of Waloddi Weibull. Methods derived from Robert B. Abernethy (2008, ISBN 0-965306-3-2), Wayne Nelson (1982, ISBN: 9780471094586) <DOI:10.1002/0471725234>, William Q. Meeker and  Lois A. Escobar (1998, ISBN: 1-471-14328-6), John I. McCool, (2012, ISBN: 9781118217986) <DOI:10.1002/9781118351994>.

--- a/src/CallgetCCC2.cpp
+++ b/src/CallgetCCC2.cpp
@@ -69,7 +69,9 @@ else   {
      qwl=T2[Fbl/i-5];
      qwu=T2[Fbu/i-5];
 /* Then interpolate using log(F) and log(Fbounds) */
-     qwccc2=qwl+((log(F)-log(Fbl))/(log(Fbu)-log(Fbl))*(qwu-qwl));
+/* casting integers to double for arguments to the log function */
+/* for complieance using platform: i386-pc-solaris2.10 (32-bit) */
+     qwccc2=qwl+((log((double) F)-log((double) Fbl))/(log((double) Fbu)-log((double) Fbl))*(qwu-qwl));
      CCC2=1-1/exp(qwccc2);
     }
    }else{


### PR DESCRIPTION
log function was applied to integers, was not universially accepted. Now the integers have been specifically cast to double for arguments to the log function